### PR TITLE
Update SmartPhone.java

### DIFF
--- a/src/main/java/HalationCode/relics/aobuta/SmartPhone.java
+++ b/src/main/java/HalationCode/relics/aobuta/SmartPhone.java
@@ -75,7 +75,8 @@ public class SmartPhone extends CustomRelic implements OnSkipCardRelic {
             doTheThing = true;
         }
         if (!SmartPhonePatch.smartSkip && !SmartPhonePatch.smartBowl && isCombat) {
-            if (!c.cardID.equals(SmartPhonePatch.smartCard.cardID)) {
+            if (SmartPhonePatch.smartCard != null &&
+                    !c.cardID.equals(SmartPhonePatch.smartCard.cardID)) {
                 doTheThing = true;
             }
             SmartPhonePatch.smartCard = null;


### PR DESCRIPTION
Fix bug reported at https://steamcommunity.com/workshop/filedetails/discussion/1609810237/3203652426714336298/

ReplayTheSpire's ring relics have ways of obtaining cards that don't involve RewardItems and don't invoke the patch that sets SmartPhonePatch.smartCard.

To be specific, it was a RingOfGreed.